### PR TITLE
Fix find a bean definition

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,6 @@
 projectVersion=4.0.0.BUILD-SNAPSHOT
 projectGroup=io.micronaut.beanvalidation
-micronautDocsVersion=2.0.0
-micronautVersion=3.2.3
-micronautTestVersion=3.0.5
-groovyVersion=3.0.9
-spockVersion=2.0-groovy-3.0
+micronautSharedSettingVersion=5.3.9
 
 title=Micronaut Hibernate Validator Configuration
 projectDesc=Provides integration between Micronaut and Hibernate Validator

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,8 @@
 [versions]
+micronaut = "3.5.0"
+micronaut-docs = "2.0.0"
+groovy = "3.0.9"
+
 glassfish-el = '2.2.1-b05'
 glassfish-javax-el = '3.0.1-b12'
 hibernate-validator = '6.1.7.Final'

--- a/hibernate-validator/build.gradle
+++ b/hibernate-validator/build.gradle
@@ -11,12 +11,14 @@ dependencies {
     implementation mn.micronaut.inject
     implementation mn.micronaut.validation
     runtimeOnly libs.glassfish.javax.el
+
     testAnnotationProcessor mn.micronaut.inject.java
     testCompileOnly mn.micronaut.inject.groovy
+    testImplementation mn.micronaut.http.server.netty
 }
 
 micronautBuild {
     resolutionStrategy {
-        force 'org.hibernate:hibernate-validator:6.1.7.Final'
+        force (libs.hibernate.validator)
     }
 }

--- a/hibernate-validator/build.gradle
+++ b/hibernate-validator/build.gradle
@@ -21,4 +21,8 @@ micronautBuild {
     resolutionStrategy {
         force (libs.hibernate.validator)
     }
+    binaryCompatibility {
+        // Last version 3.0.0 is way to old
+        enabled.set(false)
+    }
 }

--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/MicronautHibernateValidator.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/MicronautHibernateValidator.java
@@ -52,7 +52,6 @@ import java.util.Set;
 @Replaces(DefaultValidator.class)
 public class MicronautHibernateValidator extends DefaultValidator implements Validator, ExecutableMethodValidator, ReactiveValidator, AnnotatedElementValidator, BeanDefinitionValidator {
 
-    private final ValidatorFactory validatorFactory;
     private final javax.validation.Validator validator;
 
     /**
@@ -63,7 +62,6 @@ public class MicronautHibernateValidator extends DefaultValidator implements Val
      */
     protected MicronautHibernateValidator(ValidatorFactory validatorFactory, @NonNull ValidatorConfiguration configuration) {
         super(configuration);
-        this.validatorFactory = validatorFactory;
         this.validator = validatorFactory.getValidator();
     }
 

--- a/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/MicronautHibernateValidatorTest.groovy
+++ b/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/MicronautHibernateValidatorTest.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.configuration.hibernate.validator
+
+import io.micronaut.runtime.EmbeddedApplication
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class MicronautHibernateValidatorTest extends Specification {
+
+    @Inject
+    EmbeddedApplication application
+
+    def testItWorks() {
+        expect:
+            application.isRunning()
+    }
+
+}

--- a/hibernate-validator/src/test/resources/application.yml
+++ b/hibernate-validator/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+micronaut:
+  executors:
+    io:
+      type: fixed
+      number-of-threads: 20
+    scheduled:
+      type: fixed
+      number-of-threads: 20

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,7 @@
 pluginManagement {
+    plugins {
+        id 'io.micronaut.build.shared.settings' version getProperty("micronautSharedSettingVersion")
+    }
     repositories {
         gradlePluginPortal()
         mavenCentral()
@@ -6,22 +9,13 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.2.3'
+    id 'io.micronaut.build.shared.settings'
 }
 
 rootProject.name = 'hibernate-validator-parent'
 
 include 'hibernate-validator'
 
-enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
-
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-    }
-    versionCatalogs {
-        mn {
-            from "io.micronaut:micronaut-bom:${providers.gradleProperty('micronautVersion').get()}"
-        }
-    }
+micronautBuild {
+    importMicronautCatalog()
 }


### PR DESCRIPTION
The method `findBeanDefinition` documents that `NonUniqueBeanException` can be thrown.