### PR TITLE
build: use glassfish-jakarta-el instead of org.glassfish:javax.el

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,13 @@
 micronaut = "3.6.3"
 micronaut-docs = "2.0.0"
 groovy = "3.0.12"
-
 glassfish-el = '2.2.1-b05'
 glassfish-javax-el = '3.0.1-b12'
+glassfish-jakarta-el = '3.0.4'
 hibernate-validator = '6.2.5.Final'
 
 [libraries]
 glassfish-el = { module = 'org.glassfish.web:el-impl', version.ref = 'glassfish-el' }
 glassfish-javax-el = { module = 'org.glassfish:javax.el', version.ref = 'glassfish-javax-el' }
+glassfish-jakarta-el = { module = 'org.glassfish:jakarta.el', version.ref = 'glassfish-jakarta-el'  }
 hibernate-validator = { module = 'org.hibernate:hibernate-validator', version.ref = 'hibernate-validator' }

--- a/hibernate-validator/build.gradle
+++ b/hibernate-validator/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation libs.hibernate.validator
     implementation mn.micronaut.inject
     implementation mn.micronaut.validation
-    runtimeOnly libs.glassfish.javax.el
+    runtimeOnly libs.glassfish.jakarta.el
 
     testAnnotationProcessor mn.micronaut.inject.java
     testCompileOnly mn.micronaut.inject.groovy


### PR DESCRIPTION
Refernece to Hibernate Validator documentation mentioning Unified Expression Language

https://docs.jboss.org/hibernate/validator/6.0/reference/en-US/html_single/#validator-gettingstarted-uel

Related CVE:

https://nvd.nist.gov/vuln/detail/CVE-2021-28170#vulnConfigurationsArea

https://securitylab.github.com/advisories/GHSL-2020-021-jakarta-el/

Close: https://github.com/micronaut-projects/micronaut-hibernate-validator/issues/245