### PR TITLE
fix: add @Primary annotation for DefaultConstraintValidatorFactory

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ managed-hibernate-validator = '8.0.1.Final'
 
 micronaut-serde = "2.7.0"
 micronaut-test = "4.0.0"
-micronaut-validation = "4.2.0"
+micronaut-validation = "4.4.0"
 
 groovy = "4.0.13"
 

--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/DefaultConstraintValidatorFactory.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/DefaultConstraintValidatorFactory.java
@@ -16,6 +16,7 @@
 package io.micronaut.configuration.hibernate.validator;
 
 import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.exceptions.NoSuchBeanException;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.inject.DisposableBeanDefinition;
@@ -31,6 +32,7 @@ import jakarta.validation.ConstraintValidatorFactory;
  * @author James Kleeh
  * @since 1.1.0
  */
+@Primary
 @Singleton
 public class DefaultConstraintValidatorFactory implements ConstraintValidatorFactory {
 


### PR DESCRIPTION
A `ConstraintValidationFactory` aws added to Micronaut Validation in [PR 288](https://github.com/micronaut-projects/micronaut-validation/pull/288). This PR sets the Hibernate Validator as the primary `ConstraintValidatorFactory` in case there are many in the classpath and avoids:

```
Caused by: io.micronaut.context.exceptions.NonUniqueBeanException: 
Multiple possible bean candidates found: [DefaultInternalConstraintValidatorFactory, DefaultConstraintValidatorFactory]
```

see: https://github.com/micronaut-projects/micronaut-sql/issues/1266