### PR TITLE
Register the Hibernate validation message bundle

### DIFF
--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateMessageBundle.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateMessageBundle.java
@@ -6,7 +6,7 @@ import io.micronaut.core.order.Ordered;
 import jakarta.inject.Singleton;
 
 @Singleton
-@Requires(bean = MicronautHibernateValidator.class)
+@Requires(resources = "classpath:org/hibernate/validator/ValidationMessages.properties")
 public class HibernateMessageBundle extends ResourceBundleMessageSource {
     public HibernateMessageBundle() {
         super("org.hibernate.validator.ValidationMessages");

--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateMessageBundle.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateMessageBundle.java
@@ -1,0 +1,19 @@
+package io.micronaut.configuration.hibernate.validator;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.i18n.ResourceBundleMessageSource;
+import io.micronaut.core.order.Ordered;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(bean = MicronautHibernateValidator.class)
+public class HibernateMessageBundle extends ResourceBundleMessageSource {
+    public HibernateMessageBundle() {
+        super("org.hibernate.validator.ValidationMessages");
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateMessageBundle.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateMessageBundle.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.configuration.hibernate.validator;
 
 import io.micronaut.context.annotation.Requires;

--- a/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/ValidatedBeanSpec.groovy
+++ b/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/ValidatedBeanSpec.groovy
@@ -32,8 +32,6 @@ import jakarta.inject.Singleton
  */
 class ValidatedBeanSpec extends Specification {
 
-    @Issue("https://github.com/micronaut-projects/micronaut-validation/issues/101")
-    @PendingFeature
     void "test validated bean invalid bean"() {
         given:
         System.setProperty("a.url", "test")


### PR DESCRIPTION
Register the Hibernate validation message bundle, so that messages are interpolated correctly. Fixes #410 .

I'm not really sure what made this necessary. I do know that it broke between Micronaut 3 and 4.
Of course, I'm open to other ideas. This was the first one I had that worked.