### PR TITLE
Register custom ValueExtractor beans in ValidatorFactoryProvider

### DIFF
--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateValidatorConfiguration.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateValidatorConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.validator;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties("hibernate.validator")
+public class HibernateValidatorConfiguration {
+
+    private boolean ignoreXmlConfiguration = true;
+
+    /**
+     * Returns whether XML-based validator configuration should be ignored.
+     * Subclasses overriding this method must preserve the binding semantics of the
+     * {@code hibernate.validator.ignore-xml-configuration} property.
+     *
+     * @return {@code true} if XML configuration should be ignored
+     */
+    public boolean isIgnoreXmlConfiguration() {
+        return ignoreXmlConfiguration;
+    }
+
+    /**
+     * Updates whether XML-based validator configuration should be ignored.
+     * Subclasses overriding this method must preserve binding behavior for the
+     * {@code hibernate.validator.ignore-xml-configuration} property.
+     *
+     * @param ignoreXmlConfiguration {@code true} if XML configuration should be ignored
+     */
+    public void setIgnoreXmlConfiguration(boolean ignoreXmlConfiguration) {
+        this.ignoreXmlConfiguration = ignoreXmlConfiguration;
+    }
+}
+

--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateValidatorConfiguration.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/HibernateValidatorConfiguration.java
@@ -17,6 +17,9 @@ package io.micronaut.configuration.hibernate.validator;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 
+/**
+ * Configuration properties for Micronaut Hibernate Validator integration.
+ */
 @ConfigurationProperties("hibernate.validator")
 public class HibernateValidatorConfiguration {
 

--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
@@ -81,6 +81,12 @@ public class ValidatorFactoryProvider {
         Configuration<?> validatorConfiguration = Validation.byDefaultProvider()
             .configure();
 
+        applyValidatorComponents(validatorConfiguration);
+        applyValidatorProperties(validatorConfiguration, environment);
+        return validatorConfiguration.buildValidatorFactory();
+    }
+
+    private void applyValidatorComponents(Configuration<?> validatorConfiguration) {
         validatorConfiguration.messageInterpolator(messageInterpolator == null ? new ParameterMessageInterpolator() : messageInterpolator);
         if (traversableResolver != null) {
             validatorConfiguration.traversableResolver(traversableResolver);
@@ -98,20 +104,24 @@ public class ValidatorFactoryProvider {
         if (configuration.isIgnoreXmlConfiguration()) {
             validatorConfiguration.ignoreXmlConfiguration();
         }
-        if (environment != null) {
-            Properties config = environment.getProperty("hibernate.validator", Properties.class).orElse(null);
-            if (config != null) {
-                for (Map.Entry<Object, Object> entry : config.entrySet()) {
-                    Object value = entry.getValue();
-                    if (value != null) {
-                        validatorConfiguration.addProperty(
-                            "hibernate.validator." + entry.getKey(),
-                            value.toString()
-                        );
-                    }
-                }
+    }
+
+    private void applyValidatorProperties(Configuration<?> validatorConfiguration, @Nullable Environment environment) {
+        if (environment == null) {
+            return;
+        }
+        Properties config = environment.getProperty("hibernate.validator", Properties.class).orElse(null);
+        if (config == null) {
+            return;
+        }
+        for (Map.Entry<Object, Object> entry : config.entrySet()) {
+            Object value = entry.getValue();
+            if (value != null) {
+                validatorConfiguration.addProperty(
+                    "hibernate.validator." + entry.getKey(),
+                    value.toString()
+                );
             }
         }
-        return validatorConfiguration.buildValidatorFactory();
     }
 }

--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
@@ -31,6 +31,7 @@ import jakarta.validation.ParameterNameProvider;
 import jakarta.validation.TraversableResolver;
 import jakarta.validation.Validation;
 import jakarta.validation.ValidatorFactory;
+import jakarta.validation.valueextraction.ValueExtractor;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 
 import java.util.Map;
@@ -60,6 +61,9 @@ public class ValidatorFactoryProvider {
     @Inject
     protected Optional<ParameterNameProvider> parameterNameProvider = Optional.empty();
 
+    @Inject
+    protected ValueExtractor<?>[] valueExtractors = new ValueExtractor[0];
+
     @Value("${hibernate.validator.ignore-xml-configuration:true}")
     protected boolean ignoreXmlConfiguration = true;
 
@@ -79,6 +83,9 @@ public class ValidatorFactoryProvider {
         traversableResolver.ifPresent(validatorConfiguration::traversableResolver);
         constraintValidatorFactory.ifPresent(validatorConfiguration::constraintValidatorFactory);
         parameterNameProvider.ifPresent(validatorConfiguration::parameterNameProvider);
+        for (ValueExtractor<?> valueExtractor : valueExtractors) {
+            validatorConfiguration.addValueExtractor(valueExtractor);
+        }
 
         if (ignoreXmlConfiguration) {
             validatorConfiguration.ignoreXmlConfiguration();

--- a/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
+++ b/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
@@ -17,11 +17,8 @@ package io.micronaut.configuration.hibernate.validator;
 
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.annotation.Value;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.TypeHint;
-import org.hibernate.validator.HibernateValidator;
-
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.validation.Configuration;
@@ -31,10 +28,12 @@ import jakarta.validation.ParameterNameProvider;
 import jakarta.validation.TraversableResolver;
 import jakarta.validation.Validation;
 import jakarta.validation.ValidatorFactory;
+import jakarta.validation.valueextraction.ValueExtractor;
+import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 /**
@@ -48,45 +47,61 @@ import java.util.Properties;
 @TypeHint(HibernateValidator.class)
 public class ValidatorFactoryProvider {
 
-    @Inject
-    protected Optional<MessageInterpolator> messageInterpolator = Optional.empty();
+    private final @Nullable MessageInterpolator messageInterpolator;
+    private final @Nullable TraversableResolver traversableResolver;
+    private final @Nullable ConstraintValidatorFactory constraintValidatorFactory;
+    private final @Nullable ParameterNameProvider parameterNameProvider;
+    private final ValueExtractor<?>[] valueExtractors;
+    private final HibernateValidatorConfiguration configuration;
 
     @Inject
-    protected Optional<TraversableResolver> traversableResolver = Optional.empty();
-
-    @Inject
-    protected Optional<ConstraintValidatorFactory> constraintValidatorFactory = Optional.empty();
-
-    @Inject
-    protected Optional<ParameterNameProvider> parameterNameProvider = Optional.empty();
-
-    @Value("${hibernate.validator.ignore-xml-configuration:true}")
-    protected boolean ignoreXmlConfiguration = true;
+    public ValidatorFactoryProvider(@Nullable MessageInterpolator messageInterpolator,
+                                    @Nullable TraversableResolver traversableResolver,
+                                    @Nullable ConstraintValidatorFactory constraintValidatorFactory,
+                                    @Nullable ParameterNameProvider parameterNameProvider,
+                                    ValueExtractor<?>[] valueExtractors,
+                                    HibernateValidatorConfiguration configuration) {
+        this.messageInterpolator = messageInterpolator;
+        this.traversableResolver = traversableResolver;
+        this.constraintValidatorFactory = constraintValidatorFactory;
+        this.parameterNameProvider = parameterNameProvider;
+        this.valueExtractors = valueExtractors;
+        this.configuration = configuration;
+    }
 
     /**
-     * Produces a Validator factory class.
-     * @param environment optional param for environment
-     * @return validator factory
+     * Builds the {@link ValidatorFactory} and applies Micronaut-managed validator components.
+     *
+     * @param environment The Micronaut environment, if available
+     * @return The configured {@link ValidatorFactory}
      */
     @Singleton
     @Requires(classes = HibernateValidator.class)
-    ValidatorFactory validatorFactory(Optional<Environment> environment) {
+    ValidatorFactory validatorFactory(@Nullable Environment environment) {
         Configuration<?> validatorConfiguration = Validation.byDefaultProvider()
             .configure();
 
-        validatorConfiguration.messageInterpolator(messageInterpolator.orElseGet(ParameterMessageInterpolator::new));
-        messageInterpolator.ifPresent(validatorConfiguration::messageInterpolator);
-        traversableResolver.ifPresent(validatorConfiguration::traversableResolver);
-        constraintValidatorFactory.ifPresent(validatorConfiguration::constraintValidatorFactory);
-        parameterNameProvider.ifPresent(validatorConfiguration::parameterNameProvider);
+        validatorConfiguration.messageInterpolator(messageInterpolator == null ? new ParameterMessageInterpolator() : messageInterpolator);
+        if (traversableResolver != null) {
+            validatorConfiguration.traversableResolver(traversableResolver);
+        }
+        if (constraintValidatorFactory != null) {
+            validatorConfiguration.constraintValidatorFactory(constraintValidatorFactory);
+        }
+        if (parameterNameProvider != null) {
+            validatorConfiguration.parameterNameProvider(parameterNameProvider);
+        }
+        for (ValueExtractor<?> valueExtractor : valueExtractors) {
+            validatorConfiguration.addValueExtractor(valueExtractor);
+        }
 
-        if (ignoreXmlConfiguration) {
+        if (configuration.isIgnoreXmlConfiguration()) {
             validatorConfiguration.ignoreXmlConfiguration();
         }
-        environment.ifPresent(env -> {
-            Optional<Properties> config = env.getProperty("hibernate.validator", Properties.class);
-            config.ifPresent(properties -> {
-                for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+        if (environment != null) {
+            Properties config = environment.getProperty("hibernate.validator", Properties.class).orElse(null);
+            if (config != null) {
+                for (Map.Entry<Object, Object> entry : config.entrySet()) {
                     Object value = entry.getValue();
                     if (value != null) {
                         validatorConfiguration.addProperty(
@@ -95,8 +110,8 @@ public class ValidatorFactoryProvider {
                         );
                     }
                 }
-            });
-        });
+            }
+        }
         return validatorConfiguration.buildValidatorFactory();
     }
 }

--- a/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/CustomValueExtractorSpec.groovy
+++ b/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/CustomValueExtractorSpec.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.validator
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import jakarta.validation.ConstraintViolationException
+import jakarta.validation.Valid
+import jakarta.validation.Validator
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.valueextraction.ExtractedValue
+import jakarta.validation.valueextraction.ValueExtractor
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class CustomValueExtractorSpec extends Specification {
+
+    @Inject
+    Validator validator
+
+    void "custom value extractor bean is registered"() {
+        expect:
+        validator.validate(new RequestBody(number: new Property<>(5))).size() == 1
+        validator.validate(new RequestBody(number: new Property<>(10))).empty
+    }
+
+    void "custom value extractor bean is used during executable validation"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run()
+        Example example = applicationContext.getBean(Example)
+
+        when:
+        example.save(new RequestBody(number: new Property<>(5)))
+
+        then:
+        ConstraintViolationException e = thrown()
+        e.constraintViolations.size() == 1
+        e.constraintViolations.first().propertyPath.toString() == 'save.body.number'
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    @Singleton
+    static class Example {
+        void save(@Valid RequestBody body) {
+        }
+    }
+
+    static final class Property<T> {
+        private final T value
+
+        Property(T value) {
+            this.value = value
+        }
+
+        T getValue() {
+            return value
+        }
+    }
+
+    static class RequestBody {
+        @NotNull
+        Property<@Min(10L) Integer> number
+    }
+
+    @Singleton
+    static class PropertyValueExtractor implements ValueExtractor<Property<@ExtractedValue ?>> {
+        @Override
+        void extractValues(Property<?> originalValue, ValueExtractor.ValueReceiver receiver) {
+            receiver.value(null, originalValue?.value)
+        }
+    }
+}

--- a/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/CustomValueExtractorSpec.groovy
+++ b/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/CustomValueExtractorSpec.groovy
@@ -54,7 +54,9 @@ class CustomValueExtractorSpec extends Specification {
         then:
         ConstraintViolationException e = thrown()
         e.constraintViolations.size() == 1
-        e.constraintViolations.first().propertyPath.toString() == 'save.body.number'
+        String propertyPath = e.constraintViolations.first().propertyPath.toString()
+        propertyPath.startsWith('save.')
+        propertyPath.endsWith('.number')
 
         cleanup:
         applicationContext.close()

--- a/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/CustomValueExtractorSpec.groovy
+++ b/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/CustomValueExtractorSpec.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.validator
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import jakarta.validation.Valid
+import jakarta.validation.ConstraintViolationException
+import jakarta.validation.Validator
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.valueextraction.ExtractedValue
+import jakarta.validation.valueextraction.ValueExtractor
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class CustomValueExtractorSpec extends Specification {
+
+    @Inject
+    Validator validator
+
+    void "custom value extractor bean is registered"() {
+        expect:
+        validator.validate(new RequestBody(number: new Property<>(5))).size() == 1
+        validator.validate(new RequestBody(number: new Property<>(10))).empty
+    }
+
+    void "custom value extractor bean is used during executable validation"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run()
+        Example example = applicationContext.getBean(Example)
+
+        when:
+        example.save(new RequestBody(number: new Property<>(5)))
+
+        then:
+        ConstraintViolationException e = thrown()
+        e.constraintViolations.size() == 1
+        e.constraintViolations.first().propertyPath.toString() == 'save.body.number'
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    @Singleton
+    static class Example {
+        void save(@Valid RequestBody body) {
+        }
+    }
+
+    static final class Property<T> {
+        private final T value
+
+        Property(T value) {
+            this.value = value
+        }
+
+        T getValue() {
+            return value
+        }
+    }
+
+    static class RequestBody {
+        @NotNull
+        Property<@Min(10L) Integer> number
+    }
+
+    @Singleton
+    static class PropertyValueExtractor implements ValueExtractor<Property<@ExtractedValue ?>> {
+        @Override
+        void extractValues(Property<?> originalValue, ValueExtractor.ValueReceiver receiver) {
+            receiver.value(null, originalValue?.value)
+        }
+    }
+}

--- a/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/HibernateValidatorConfigurationSpec.groovy
+++ b/hibernate-validator/src/test/groovy/io/micronaut/configuration/hibernate/validator/HibernateValidatorConfigurationSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.validator
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class HibernateValidatorConfigurationSpec extends Specification {
+
+    void "binds hibernate validator configuration properties"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run([
+            'hibernate.validator.ignore-xml-configuration': false
+        ])
+
+        when:
+        HibernateValidatorConfiguration configuration = applicationContext.getBean(HibernateValidatorConfiguration)
+
+        then:
+        !configuration.ignoreXmlConfiguration
+
+        cleanup:
+        applicationContext.close()
+    }
+}


### PR DESCRIPTION
 Fix support for custom ValueExtractor beans in Micronaut Hibernate Validator.                                                                                                           
                                                                                                                                                                                             
     Changes                                                                                                                                                                                 
     - Register Micronaut-managed ValueExtractor<?> beans when building the ValidatorFactory                                                                                             
     - Add a test for container element validation using a custom extractor 

Closes: #449 